### PR TITLE
Replaced `enum IoRegs` with `mod io_regs`

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -1,6 +1,6 @@
 use super::bit_ops::BitGetSet;
 use super::memory::Memory;
-use super::memory_values::IoRegs;
+use super::memory_values::io_regs;
 use super::registers::Registers;
 
 pub const CLOCK_SPEED: u64 = 4_194_304;
@@ -27,12 +27,12 @@ impl Interrupt {
     }
 
     fn reset_flag(&self, memory: &mut Memory) {
-        let flag = memory.get_io(IoRegs::IF);
+        let flag = memory.get_io(io_regs::IF);
         let new_flag = match self {
             Interrupt::VBlank => flag.reset_bit(0),
             Interrupt::Timer => flag.reset_bit(2),
         };
-        memory.set_io(IoRegs::IF, new_flag);
+        memory.set_io(io_regs::IF, new_flag);
     }
 }
 
@@ -56,8 +56,8 @@ impl Cpu {
     }
 
     pub fn check_interrupts(&mut self, memory: &mut Memory) {
-        let interrupt_request = memory.get_io(IoRegs::IF);
-        let interrupt_enable = memory.get_io(IoRegs::IE);
+        let interrupt_request = memory.get_io(io_regs::IF);
+        let interrupt_enable = memory.get_io(io_regs::IE);
         let interrupts = interrupt_request & interrupt_enable;
         if interrupts.get_bit(0) {
             self.try_interrupt(Interrupt::VBlank, memory);
@@ -669,8 +669,8 @@ impl Cpu {
             self.halt_state = HaltState::Mode1;
             self.registers.pc += 1;
         } else {
-            let ie_flag = memory.get_io(IoRegs::IE);
-            let if_flag = memory.get_io(IoRegs::IF);
+            let ie_flag = memory.get_io(io_regs::IE);
+            let if_flag = memory.get_io(io_regs::IF);
             if (ie_flag & if_flag).trailing_zeros() >= 5 {
                 self.halt_state = HaltState::Mode2;
                 self.registers.pc += 1;

--- a/src/lcd/lcd_registers.rs
+++ b/src/lcd/lcd_registers.rs
@@ -49,19 +49,19 @@ impl<'a> LCDRegisters<'a> {
         }
     }
 
-    create_getter!(get_lcdc, lcdc, IoRegs::LCDC);
+    create_getter!(get_lcdc, lcdc, io_regs::LCDC);
 
-    create_getter!(get_ly, ly, IoRegs::LY);
-    create_setter!(set_ly, ly, IoRegs::LY);
+    create_getter!(get_ly, ly, io_regs::LY);
+    create_setter!(set_ly, ly, io_regs::LY);
 
-    create_getter!(get_lyc, lyc, IoRegs::LYC);
+    create_getter!(get_lyc, lyc, io_regs::LYC);
 
-    create_getter!(get_scy, scy, IoRegs::SCY);
+    create_getter!(get_scy, scy, io_regs::SCY);
 
-    create_getter!(get_bgp, bgp, IoRegs::BGP);
+    create_getter!(get_bgp, bgp, io_regs::BGP);
 
-    create_getter!(get_stat, stat, IoRegs::STAT);
-    create_setter!(set_stat, stat, IoRegs::STAT);
+    create_getter!(get_stat, stat, io_regs::STAT);
+    create_setter!(set_stat, stat, io_regs::STAT);
 
     pub fn check_enabled(&mut self) -> bool {
         self.get_lcdc().get_bit(7)
@@ -84,8 +84,8 @@ impl<'a> LCDRegisters<'a> {
     }
 
     pub fn set_interrupt_bit(&mut self) {
-        let if_reg = self.memory.get_io(IoRegs::IF).set_bit(0);
-        self.memory.set_io(IoRegs::IF, if_reg);
+        let if_reg = self.memory.get_io(io_regs::IF).set_bit(0);
+        self.memory.set_io(io_regs::IF, if_reg);
     }
 
     pub fn set_lcd_mode(&mut self, mode: u8) {

--- a/src/lcd/mod.rs
+++ b/src/lcd/mod.rs
@@ -129,7 +129,7 @@ mod tests {
     use cartridge::Cartridge;
     use lcd::LCD;
     use memory::Memory;
-    use memory_values::IoRegs;
+    use memory_values::io_regs;
 
     // Check lcd against old algorithm for calculating ly register
     #[test]
@@ -142,14 +142,14 @@ mod tests {
 
         let mut lcd = LCD::new();
 
-        memory.set_io(IoRegs::LCDC, 0b1000_0000);
+        memory.set_io(io_regs::LCDC, 0b1000_0000);
         // Run for 10 frames
         for cycles in 0..(70224 * 10) {
             let frame_time = cycles % (456 * 154);
             let test_ly = (frame_time / 456) as u8;
 
             lcd.tick(&mut memory, cycles, |_, _| {});
-            let lcd_ly = memory.get_io(IoRegs::LY);
+            let lcd_ly = memory.get_io(io_regs::LY);
 
             assert_eq!(
                 lcd_ly, test_ly,
@@ -174,11 +174,11 @@ mod tests {
 
         let mut lcd = LCD::new();
 
-        memory.set_io(IoRegs::LCDC, 0b1000_0000);
+        memory.set_io(io_regs::LCDC, 0b1000_0000);
 
         {
-            let stat = memory.get_io(IoRegs::STAT);
-            let ly = memory.get_io(IoRegs::LY);
+            let stat = memory.get_io(io_regs::STAT);
+            let ly = memory.get_io(io_regs::LY);
             assert_eq!(stat & 0b11, 0);
             assert_eq!(ly, 0);
         }
@@ -196,32 +196,32 @@ mod tests {
             // Mode 0 for first 4 cycles
             for c in cycles..(cycles + 4) {
                 lcd.tick(memory, c, |_, _| {});
-                let stat = memory.get_io(IoRegs::STAT);
-                let ly = memory.get_io(IoRegs::LY);
+                let stat = memory.get_io(io_regs::STAT);
+                let ly = memory.get_io(io_regs::LY);
                 assert_eq!(stat & 0b11, 0);
                 assert_eq!(ly as u64, line);
             }
             // Test line 0 timings
             for c in (cycles + 4)..(cycles + 84) {
                 lcd.tick(memory, c, |_, _| {});
-                let stat = memory.get_io(IoRegs::STAT);
-                let ly = memory.get_io(IoRegs::LY);
+                let stat = memory.get_io(io_regs::STAT);
+                let ly = memory.get_io(io_regs::LY);
                 assert_eq!(stat & 0b11, 2);
                 assert_eq!(ly as u64, line);
             }
             {
                 // Mode 3 for indefinate time starting at 84
                 lcd.tick(memory, cycles + 84, |_, _| {});
-                let stat = memory.get_io(IoRegs::STAT);
-                let ly = memory.get_io(IoRegs::LY);
+                let stat = memory.get_io(io_regs::STAT);
+                let ly = memory.get_io(io_regs::LY);
                 assert_eq!(stat & 0b11, 3);
                 assert_eq!(ly as u64, line);
             }
             // By 448, mode should be 0, and should remain till end of scanline
             for c in (cycles + 448)..(cycles + 456) {
                 lcd.tick(memory, c, |_, _| {});
-                let stat = memory.get_io(IoRegs::STAT);
-                let ly = memory.get_io(IoRegs::LY);
+                let stat = memory.get_io(io_regs::STAT);
+                let ly = memory.get_io(io_regs::LY);
                 assert_eq!(stat & 0b11, 0);
                 assert_eq!(ly as u64, line);
             }
@@ -233,16 +233,16 @@ mod tests {
             // Mode 0 for first 4 cycles
             for c in cycles..(cycles + 4) {
                 lcd.tick(memory, c, |_, _| {});
-                let stat = memory.get_io(IoRegs::STAT);
-                let ly = memory.get_io(IoRegs::LY);
+                let stat = memory.get_io(io_regs::STAT);
+                let ly = memory.get_io(io_regs::LY);
                 assert_eq!(stat & 0b11, 0);
                 assert_eq!(ly as u64, line);
             }
             // Mode 1 for remaining cycles
             for c in (cycles + 4)..(cycles + 456) {
                 lcd.tick(memory, c, |_, _| {});
-                let stat = memory.get_io(IoRegs::STAT);
-                let ly = memory.get_io(IoRegs::LY);
+                let stat = memory.get_io(io_regs::STAT);
+                let ly = memory.get_io(io_regs::LY);
                 assert_eq!(stat & 0b11, 1);
                 assert_eq!(ly as u64, line);
             }
@@ -253,8 +253,8 @@ mod tests {
             // Mode 1 for all cycles
             for c in cycles..(cycles + 456) {
                 lcd.tick(memory, c, |_, _| {});
-                let stat = memory.get_io(IoRegs::STAT);
-                let ly = memory.get_io(IoRegs::LY);
+                let stat = memory.get_io(io_regs::STAT);
+                let ly = memory.get_io(io_regs::LY);
                 assert_eq!(stat & 0b11, 1);
                 assert_eq!(ly as u64, line);
             }

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -122,7 +122,7 @@ impl Memory {
 
     fn set_io_indexed(&mut self, index: usize, value: u8) {
         match index {
-            JOYP => self.joypad.set_u8(value),
+            io_regs::JOYP => self.joypad.set_u8(value),
             0xff01 => self.serial_data.push(value),
             0xff50 => self.boot_rom_enabled = false,
             _ => (),
@@ -134,25 +134,25 @@ impl Memory {
     fn get_io_indexed(&self, index: usize) -> u8 {
         let value = self.io[index - IO_START];
         match index {
-            JOYP => self.joypad.get_u8(),
+            io_regs::JOYP => self.joypad.get_u8(),
             _ => value,
         }
     }
 
-    pub fn get_io(&self, reg: IoRegs) -> u8 {
+    pub fn get_io(&self, reg: usize) -> u8 {
         match reg {
             // IoRegs is not in normal io range
             // so is not accessible in get_io_indexed
-            IoRegs::IE => self.interrupt_enable_register,
+            io_regs::IE => self.interrupt_enable_register,
             _ => self.get_io_indexed(reg as usize),
         }
     }
 
-    pub fn set_io(&mut self, reg: IoRegs, value: u8) {
+    pub fn set_io(&mut self, reg: usize, value: u8) {
         match reg {
             // IoRegs is not in normal io range
             // so is not accessible in set_io_indexed
-            IoRegs::IE => self.interrupt_enable_register = value,
+            io_regs::IE => self.interrupt_enable_register = value,
             _ => self.set_io_indexed(reg as usize, value),
         }
     }

--- a/src/memory_values.rs
+++ b/src/memory_values.rs
@@ -39,25 +39,23 @@ pub const TILE_MAP_2: u16 = 0x9c00;
 pub const TILE_DATA_1: u16 = 0x8800;
 pub const TILE_DATA_2: u16 = 0x8000;
 
-pub const JOYP: usize = 0xff00;
 
-#[derive(Copy, Clone)]
-pub enum IoRegs {
-    // JOYP = 0xff00,
-    TIMA = 0xff05,
-    TMA = 0xff06,
-    TAC = 0xff07,
-    IF = 0xff0f,
-    IE = 0xffff,
-    LCDC = 0xff40,
-    STAT = 0xff41,
-    SCY = 0xff42,
+pub mod io_regs {
+    pub const JOYP: usize = 0xff00;
+    pub const TIMA: usize = 0xff05;
+    pub const TMA: usize = 0xff06;
+    pub const TAC: usize = 0xff07;
+    pub const IF: usize = 0xff0f;
+    pub const IE: usize = 0xffff;
+    pub const LCDC: usize = 0xff40;
+    pub const STAT: usize = 0xff41;
+    pub const SCY: usize = 0xff42;
     // SCX = 0xff43,
-    LY = 0xff44,
-    LYC = 0xff45,
+    pub const LY: usize = 0xff44;
+    pub const LYC: usize = 0xff45;
     // WY = 0xff4a,
     // WX = 0xff4b,
-    BGP = 0xff47,
+    pub const BGP: usize = 0xff47;
     // OBP0 = 0xff48,
     // OBP1 = 0xff49,
     // DMA = 0xff46,

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -1,7 +1,7 @@
 use super::bit_ops::BitGetSet;
 use super::cpu;
 use super::memory::Memory;
-use super::memory_values::IoRegs;
+use super::memory_values::io_regs;
 
 pub struct Timer {
     enabled: bool,
@@ -24,13 +24,13 @@ impl Timer {
             self.update_time += self.cpu_cycles_per_tick();
 
             if tima == 255 {
-                memory.set_io(IoRegs::TIMA, tma);
+                memory.set_io(io_regs::TIMA, tma);
                 // println!("TIMA set to TMA({})", tma);
-                let if_reg = memory.get_io(IoRegs::IF).set_bit(2);
-                memory.set_io(IoRegs::IF, if_reg);
+                let if_reg = memory.get_io(io_regs::IF).set_bit(2);
+                memory.set_io(io_regs::IF, if_reg);
             } else {
                 // println!("TIMA set to {}", tima + 1);
-                memory.set_io(IoRegs::TIMA, tima + 1);
+                memory.set_io(io_regs::TIMA, tima + 1);
             }
         }
     }
@@ -40,9 +40,9 @@ impl Timer {
     }
 
     fn read_registers(&mut self, memory: &mut Memory, cycles: u64) -> (u8, u8) {
-        let tima = memory.get_io(IoRegs::TIMA);
-        let tma = memory.get_io(IoRegs::TMA);
-        let tac = memory.get_io(IoRegs::TAC);
+        let tima = memory.get_io(io_regs::TIMA);
+        let tma = memory.get_io(io_regs::TMA);
+        let tac = memory.get_io(io_regs::TAC);
 
         let enabled = tac.get_bit(2);
         let input_clock = match tac & 0b11 {


### PR DESCRIPTION
Was having to keep consts of various io reg numbers for use in match statements. Changing IoRegs to module allows all the same functionality being used before, but array indexing and use in match statments that take a usize.